### PR TITLE
当用户更改了模拟select的值以后，网页中默认select元素的change事件并没有触发

### DIFF
--- a/select.js
+++ b/select.js
@@ -220,6 +220,9 @@
 
 			self.select[0].selectedIndex = index;
 
+            		//需要手懂触发select的change事件;
+            		$(self.select[0]).trigger("change");
+            
 			self._value.html(st.html());
 
 			self.close();


### PR DESCRIPTION
```
//219行添加
//需要手懂触发select的change事件;
$(self.select[0]).trigger("change");
```
